### PR TITLE
feat(album): support time range filter and media-only mode

### DIFF
--- a/afdian/album/album.go
+++ b/afdian/album/album.go
@@ -29,7 +29,7 @@ func GetAlbums(cfg *config.Config, authorUrlSlug string, cookieString string, au
 	converter := md.NewConverter("", true, nil)
 	for _, album := range albumList {
 		slog.Info("Find album: ", "albumName", album.AlbumName)
-		err := GetAlbum(cfg, cookieString, authToken, album, disableComment, quickUpdate, converter)
+		err := GetAlbum(cfg, cookieString, authToken, album, disableComment, quickUpdate, converter, "", "")
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,38 @@ func GetAlbums(cfg *config.Config, authorUrlSlug string, cookieString string, au
 	return nil
 }
 
-func GetAlbum(cfg *config.Config, cookieString string, authToken string, album afdian.Album, disableComment bool, quickUpdate bool, converter *md.Converter) error {
+func GetAlbum(cfg *config.Config, cookieString string, authToken string, album afdian.Album, disableComment bool, quickUpdate bool, converter *md.Converter, fromDate string, toDate string) error {
+	// 解析时间范围
+	var fromTime, toTime time.Time
+	var hasFrom, hasTo bool
+	if fromDate != "" {
+		t, err := time.Parse("2006-01-02", fromDate)
+		if err != nil {
+			return fmt.Errorf("--from 日期格式错误，需要 YYYY-MM-DD: %w", err)
+		}
+		fromTime = t
+		hasFrom = true
+	}
+	if toDate != "" {
+		t, err := time.Parse("2006-01-02", toDate)
+		if err != nil {
+			return fmt.Errorf("--to 日期格式错误，需要 YYYY-MM-DD: %w", err)
+		}
+		// 将结束日期设置为当天结束 (23:59:59)
+		toTime = t.Add(24*time.Hour - time.Second)
+		hasTo = true
+	}
+	if hasFrom || hasTo {
+		rangeDesc := ""
+		if hasFrom {
+			rangeDesc += "从 " + fromTime.Format("2006-01-02")
+		}
+		if hasTo {
+			rangeDesc += " 到 " + toTime.Format("2006-01-02")
+		}
+		slog.Info("时间范围过滤已启用", "range", rangeDesc)
+	}
+
 	//获取作品集的所有文章
 	//album.AlbumUrl会类似于 https://afdian.com/album/xyz
 	re := regexp.MustCompile("^.*/album/")
@@ -57,6 +88,9 @@ func GetAlbum(cfg *config.Config, cookieString string, authToken string, album a
 
 	//边获取边下载
 	var i int64
+	downloadedCount := 0
+	skippedCount := 0
+	outOfRangeCount := 0
 	for i = 0; i < albumInfo.PostCount; i += 10 {
 		postList, err := afdian.GetAlbumPostPage(cfg, albumId, cookieString, i, "desc")
 		if err != nil {
@@ -64,6 +98,18 @@ func GetAlbum(cfg *config.Config, cookieString string, authToken string, album a
 		}
 
 		for _, post := range postList {
+			// 时间范围过滤
+			if hasFrom && post.PublishTime.Before(fromTime) {
+				slog.Debug("跳过（早于起始日期）", "title", post.Name, "publishTime", post.PublishTime.Format("2006-01-02"))
+				outOfRangeCount++
+				continue
+			}
+			if hasTo && post.PublishTime.After(toTime) {
+				slog.Debug("跳过（晚于结束日期）", "title", post.Name, "publishTime", post.PublishTime.Format("2006-01-02"))
+				outOfRangeCount++
+				continue
+			}
+
 			timePrefix := post.PublishTime.Format("2006-01-02_15_04_05")
 			filePath := filepath.Join(albumSaveDir, timePrefix+"_"+post.Name+".md")
 
@@ -75,12 +121,22 @@ func GetAlbum(cfg *config.Config, cookieString string, authToken string, album a
 				}
 				return err
 			}
+			if skipped {
+				skippedCount++
+			} else {
+				downloadedCount++
+			}
 			if quickUpdate && skipped {
 				slog.Info("Quick update: 检测到已存在文件，跳过剩余作品集文章", "album", albumInfo.AlbumName)
-				return nil
+				goto done
 			}
 		}
 		time.Sleep(time.Millisecond * time.Duration(afdian.DelayMs))
+	}
+
+done:
+	if hasFrom || hasTo {
+		slog.Info("时间范围过滤统计", "下载", downloadedCount, "已存在跳过", skippedCount, "超出范围跳过", outOfRangeCount)
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	CookiePath    string // cookie 文件路径
 	DownloadMedia bool   // 是否下载音频和视频，默认 false
 	SkipFailed    bool   // 下载失败时是否跳过继续，默认 false（终止程序）
+	MediaOnly     bool   // 仅下载媒体（音频/视频），不保存帖子内容
 }
 
 // NewConfig 创建配置，自动根据 host 生成 HostUrl

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	cookieString, authToken string
 	disableComment          bool
 	downloadMediaFlag       bool
+	mediaOnlyFlag           bool
 	skipFailedFlag          bool
 	quickUpdate             bool
 	debugMode               bool
@@ -73,6 +74,7 @@ func main() {
 			&cli.StringFlag{Name: "cookie", Destination: &cookiePathFlag, Value: "", Usage: "cookies.json 文件路径，默认为程序所在目录下的 cookies.json"},
 			&cli.BoolFlag{Name: "disable_comment", Destination: &disableComment, Value: false, Usage: "为true时不下载评论"},
 			&cli.BoolFlag{Name: "download_media", Destination: &downloadMediaFlag, Value: false, Usage: "下载音频和视频文件，默认不下载"},
+			&cli.BoolFlag{Name: "media_only", Destination: &mediaOnlyFlag, Value: false, Usage: "仅下载媒体文件（音频/视频），不保存帖子内容"},
 			&cli.BoolFlag{Name: "skip_failed", Destination: &skipFailedFlag, Value: false, Usage: "下载失败时跳过继续爬取，默认终止程序"},
 			&cli.BoolFlag{Name: "debug", Destination: &debugMode, Value: false, Usage: "启用调试日志"},
 		},
@@ -103,6 +105,7 @@ func main() {
 
 			cfg = config.NewConfig(afdianHost, dataDir, cookiePath)
 			cfg.DownloadMedia = downloadMediaFlag
+			cfg.MediaOnly = mediaOnlyFlag
 			cfg.SkipFailed = skipFailedFlag
 
 			// mcp 子命令不需要加载 Cookie
@@ -141,13 +144,15 @@ func main() {
 			},
 			{
 				Name:  "album",
-				Usage: "下载指定的作品集",
+				Usage: "下载指定的作品集，支持按时间范围过滤",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "url", Aliases: []string{"u"}, Destination: &albumUrl, Value: "", Usage: "待下载的作品集url"},
+					&cli.StringFlag{Name: "from", Value: "", Usage: "开始日期 (YYYY-MM-DD)，只下载此日期之后的文章"},
+					&cli.StringFlag{Name: "to", Value: "", Usage: "结束日期 (YYYY-MM-DD)，只下载此日期之前的文章"},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					converter := md.NewConverter("", true, nil)
-					return album.GetAlbum(cfg, cookieString, authToken, afdian.Album{AlbumName: "", AlbumUrl: albumUrl}, disableComment, false, converter)
+					return album.GetAlbum(cfg, cookieString, authToken, afdian.Album{AlbumName: "", AlbumUrl: albumUrl}, disableComment, false, converter, cmd.String("from"), cmd.String("to"))
 				},
 			},
 			{

--- a/storage/writer.go
+++ b/storage/writer.go
@@ -18,6 +18,24 @@ import (
 
 // SavePostIfNotExist 检查文件是否存在，不存在则下载并保存文章
 func SavePostIfNotExist(cfg *config.Config, filePath string, article afdian.Post, authToken string, disableComment bool, converter *md.Converter) (skipped bool, err error) {
+	if cfg.MediaOnly {
+		// 媒体专用模式：只下载音频/视频，不保存帖子内容
+		_, audio, video, err := afdian.GetPostContent(cfg, article.Url, authToken, converter)
+		if err != nil {
+			return false, err
+		}
+		_, err = downloadMedia(filePath, article.Name, audio, "audio", true)
+		if err != nil {
+			return false, err
+		}
+		_, err = downloadMedia(filePath, article.Name, video, "video", true)
+		if err != nil {
+			return false, err
+		}
+		slog.Info("媒体下载完成（媒体专用模式）", "article", article.Name)
+		return false, nil
+	}
+
 	_, err = os.Stat(filePath)
 	fileExists := err == nil || os.IsExist(err)
 	if !fileExists {


### PR DESCRIPTION
## 新增功能

### 1. 专辑时间范围过滤
`album` 子命令新增 `--from` 和 `--to` 参数，支持只下载指定时间段内的文章：

```bash
# 只下载 2024年全年内容
afdian-dl album -u https://afdian.com/album/xxx --from 2024-01-01 --to 2024-12-31

# 只下载 2025年1月之后的内容
afdian-dl album -u https://afdian.com/album/xxx --from 2025-01-01
```

- 日期格式：`YYYY-MM-DD`
- 边界日期包含当天（`--from` 设 00:00:00，`--to` 设 23:59:59）
- 下载完成输出过滤统计：下载数 / 已存在跳过数 / 超出范围跳过数

### 2. 媒体专用模式
新增全局参数 `--media_only`，仅下载帖子中的音频/视频文件，不保存帖子内容、图片、评论：

```bash
afdian-dl album -u https://afdian.com/album/xxx --media_only

# 支持组合使用
afdian-dl album -u https://afdian.com/album/xxx --from 2024-01-01 --to 2024-12-31 --media_only
```

- 自动启用媒体下载（无需额外加 `--download_media`）
- 不生成 `.md` 文件
- 不下载图片和评论，节省带宽和时间

### 向后兼容
- `albums`（下载所有作品集）、`motions`、`shop`、`update` 命令不受影响
- 不加新参数时行为完全一致

## 改动的文件

| 文件 | 改动 |
|------|------|
| `config/config.go` | 新增 `MediaOnly` 字段 |
| `main.go` | 新增 `--media-only` 全局参数 |
| `afdian/album/album.go` | 时间范围过滤 + 过滤统计 |
| `storage/writer.go` | `SavePostIfNotExist` 中 media-only 分支 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date range filtering for album downloads via `--from` and `--to` CLI flags (format: YYYY-MM-DD)
  * Added media-only download mode via `--media_only` flag to download only audio and video files
  * Enhanced logging with download statistics, including counts of skipped files and posts filtered by date range

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PhiFever/AfdianToMarkdown/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->